### PR TITLE
Fix code scanning alert no. 30: Incomplete URL substring sanitization

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -1,12 +1,13 @@
 import axios from "axios";
 import { CustomError, MissingParamError } from "../common/utils.js";
+import { URL } from "url";
 
 /**
  * WakaTime data fetcher.
  *
  * @param {{username: string, api_domain: string }} props Fetcher props.
  * @returns {Promise<WakaTimeData>} WakaTime data response.
- */
+*/
 const fetchWakatimeStats = async ({ username, api_domain }) => {
   if (!username) {
     throw new MissingParamError(["username"]);
@@ -14,13 +15,14 @@ const fetchWakatimeStats = async ({ username, api_domain }) => {
 
   const allowedDomains = ["wakatime.com", "another-trusted-domain.com"];
   const sanitizedDomain = api_domain ? api_domain.replace(/\/$/gi, "") : "wakatime.com";
-  if (!allowedDomains.includes(sanitizedDomain)) {
-    throw new CustomError(`Invalid API domain: '${sanitizedDomain}'`, "INVALID_API_DOMAIN");
+  const urlHost = new URL(`https://${sanitizedDomain}`).host;
+  if (!allowedDomains.includes(urlHost)) {
+    throw new CustomError(`Invalid API domain: '${urlHost}'`, "INVALID_API_DOMAIN");
   }
 
   try {
     const { data } = await axios.get(
-      `https://${sanitizedDomain}/api/v1/users/${encodeURIComponent(username)}/stats?is_including_today=true`,
+      `https://${urlHost}/api/v1/users/${encodeURIComponent(username)}/stats?is_including_today=true`,
     );
 
     return data.data;


### PR DESCRIPTION
Fixes [https://github.com/Incognito-100/github-readme-stats/security/code-scanning/30](https://github.com/Incognito-100/github-readme-stats/security/code-scanning/30)

To fix the problem, we need to parse the `api_domain` URL and check its host value against a whitelist of allowed hosts. This ensures that the domain is exactly one of the allowed domains and not just a substring match.

1. Parse the `api_domain` URL to extract the host.
2. Check if the host is in the list of allowed hosts.
3. If the host is not in the allowed list, throw an error.

We will use the `url` module from Node.js to parse the URL and extract the host.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
